### PR TITLE
Allow dictionary content control via keyword list

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,24 @@ will contain the following metadata:
    }
 }
 ```
+
+### Customization
+
+When invoking the macro, one can control what will be added
+to the build dictionary by postfixing the list of the parameters we want in the dictionary.
+See the following example:
+```rust
+m.add("__build__", pyo3_built!(py, build, "time", "git", "target"))?;
+```
+
+The following parameters are available (they mirror built categories):
+- `"build"`
+- `"time"`
+- `"deps"`
+- `"features"`
+- `"host"`
+- `"target"`
+- `"git"`
+
+The corresponding options must be enabled in the built crate and the build.rs for this to work.
+By default everything except `"git"` is enabled.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,5 @@
 #[macro_export]
 macro_rules! pyo3_built {
-    ($py: ident, $info: ident, "intro") => {
-        use pyo3::types::PyDict;
-        use pyo3::types::PyString;
-    };
     ($py: ident, $info: ident, $dict: ident, "build") => {
         // Rustc
         let build = PyDict::new($py);
@@ -72,21 +68,18 @@ macro_rules! pyo3_built {
         $dict.set_item("git", git)?;
 
     };
-    ($py: ident, $info: ident, $dict: ident, "finish") => {
-        $dict
-    };
     // Default build
     ($py: ident, $info: ident) => {
         pyo3_built!{$py, $info, "build", "time", "deps", "features", "host", "target"}
     };
     // Custom build
     ($py: ident, $info: ident, $($i:tt ),+ ) => {{
-        pyo3_built!{$py, $info, "intro"}
+        use pyo3::types::PyDict;
+        use pyo3::types::PyString;
         let info = PyDict::new($py);
         $(
             pyo3_built!{$py,$info, info, $i}
         )+
-
-        pyo3_built!{$py, $info, info, "finish"}
+        info
     }};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,10 @@
 #[macro_export]
 macro_rules! pyo3_built {
-    ($py: ident, $info: ident) => {{
+    ($py: ident, $info: ident, "intro") => {
         use pyo3::types::PyDict;
         use pyo3::types::PyString;
-
-        let info = PyDict::new($py);
-
+    };
+    ($py: ident, $info: ident, $dict: ident, "build") => {
         // Rustc
         let build = PyDict::new($py);
         build.set_item("rustc", $info::RUSTC)?;
@@ -13,8 +12,9 @@ macro_rules! pyo3_built {
         build.set_item("opt-level", $info::OPT_LEVEL)?;
         build.set_item("debug", $info::DEBUG)?;
         build.set_item("jobs", $info::NUM_JOBS)?;
-        info.set_item("build", build)?;
-
+        $dict.set_item("build", build)?;
+    };
+    ($py: ident, $info: ident, $dict: ident, "time") => {
         // info time
         let dt = $py
             .import("email.utils")?
@@ -26,27 +26,31 @@ macro_rules! pyo3_built {
             .get("datetime")?
             .to_object($py)
             .call_method1($py, "fromtimestamp", (ts,))?;*/
-        info.set_item("info-time", dt)?;
-
+        $dict.set_item("info-time", dt)?;
+    };
+    ($py: ident, $info: ident, $dict: ident, "deps") => {
         // info dependencies
         let deps = PyDict::new($py);
         for (name, version) in $info::DEPENDENCIES.iter() {
             deps.set_item(name, version)?;
         }
-        info.set_item("dependencies", deps)?;
-
+        $dict.set_item("dependencies", deps)?;
+    };
+    ($py: ident, $info: ident, $dict: ident, "features") => {
         // Features
         let features = $info::FEATURES
             .iter()
             .map(|feat| PyString::new($py, feat))
             .collect::<Vec<_>>();
-        info.set_item("features", features)?;
-
+        $dict.set_item("features", features)?;
+    };
+    ($py: ident, $info: ident, $dict: ident, "host") => {
         // Host
         let host = PyDict::new($py);
         host.set_item("triple", $info::HOST)?;
-        info.set_item("host", host)?;
-
+        $dict.set_item("host", host)?;
+    };
+    ($py: ident, $info: ident, $dict: ident, "target") => {
         // Target
         let target = PyDict::new($py);
         target.set_item("arch", $info::CFG_TARGET_ARCH)?;
@@ -57,8 +61,32 @@ macro_rules! pyo3_built {
         target.set_item("endianness", $info::CFG_ENDIAN)?;
         target.set_item("pointer-width", $info::CFG_POINTER_WIDTH)?;
         target.set_item("profile", $info::PROFILE)?;
-        info.set_item("target", target)?;
+        $dict.set_item("target", target)?;
+    };
+    ($py: ident, $info: ident, $dict: ident, "git") => {
+        let git = PyDict::new($py);
+        git.set_item("version", $info::GIT_VERSION)?;
+        git.set_item("dirty", $info::GIT_DIRTY)?;
+        git.set_item("hash", $info::GIT_COMMIT_HASH)?;
+        git.set_item("head", $info::GIT_HEAD_REF)?;
+        $dict.set_item("git", git)?;
 
-        info
+    };
+    ($py: ident, $info: ident, $dict: ident, "finish") => {
+        $dict
+    };
+    // Default build
+    ($py: ident, $info: ident) => {
+        pyo3_built!{$py, $info, "build", "time", "deps", "features", "host", "target"}
+    };
+    // Custom build
+    ($py: ident, $info: ident, $($i:tt ),+ ) => {{
+        pyo3_built!{$py, $info, "intro"}
+        let info = PyDict::new($py);
+        $(
+            pyo3_built!{$py,$info, info, $i}
+        )+
+
+        pyo3_built!{$py, $info, info, "finish"}
     }};
 }


### PR DESCRIPTION
This will allow macro users to control the content of the build dict if they want to.
Default macro usage is not affected (backward compatibility).

Changes (from commit):
- Update README.md on how to customize your dictionary
- Make macro invoke itself recursively to control what is added to the
dictionary